### PR TITLE
QA-13536: Force jnt_video to use html5 player. on base demo core as it is overriding the default

### DIFF
--- a/src/main/resources/jnt_video/html/video.jsp
+++ b/src/main/resources/jnt_video/html/video.jsp
@@ -36,7 +36,7 @@
         <video id="video-${currentNode.identifier}" class="video-js vjs-default-skin" controls <c:if test="${currentNode.properties.autoplay.boolean and not renderContext.editMode}">autoplay</c:if>
                preload="${renderContext.editMode ? "metadata" : "auto"}"
                width="${currentNode.properties.width.string}" height="${currentNode.properties.height.string}"
-               data-setup='{<c:if test="${currentNode.properties.forceFlashPlayer.boolean}">"techOrder":["flash", "html5"]</c:if>}'>
+               data-setup='{"techOrder":["html5"]}'>
           <source src="<template:module node='${currentNode.properties.source.node}' editable='false' view='hidden.contentURL' />" type='${mimeType.string == "video/x-f4v" ? "video/mp4" : mimeType.string}' />
         </video>
     </c:otherwise>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13536

## Description

Simple change to force jnt_video to use html5 player.