### PR TITLE
BACKLOG-16667: Backport fix to make add to calendar link work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <version>7.1.2.0</version>
   </parent>
   <artifactId>dx-base-demo-core</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>DX Base Demo Core</name>
   <description>This is the custom module (dx-base-demo-core) for running on a Digital Experience Manager server.</description>

--- a/src/main/resources/jnt_event/html/event.detail.jsp
+++ b/src/main/resources/jnt_event/html/event.detail.jsp
@@ -71,7 +71,7 @@
 <%-- add to calendar --%>
 <c:if test="${not empty startDate}">
     <%-- download ICS file --%>
-    <c:url var="icsUrl" value="${url.base}${currentNode.path}.generateEventIcs.do"/>
+    <c:url var="icsUrl" value="${renderContext.liveMode ? url.baseLive : url.basePreview}${currentNode.path}.generateEventIcs.do"/>
     <fmt:message key="jnt_event.ics"/>:&nbsp;
     <a data-placement="top" data-toggle="tooltip" class="ics	tooltips"
        data-original-title="<fmt:message key="jnt_event.ics"/>" href="${icsUrl}"><i class="fa fa-calendar"></i></a>

--- a/src/main/resources/jnt_event/html/event.detail.properties
+++ b/src/main/resources/jnt_event/html/event.detail.properties
@@ -1,0 +1,1 @@
+cache.expiration=0


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-16667

## Description
Backport fix to make add to calendar link work
- in page-composer
- with CSRF token
