### PR TITLE
TECH-2055: Remove misuses of <template:module> for HTML attributes

### DIFF
--- a/src/main/resources/jnt_banner/html/banner.hidden.bannerHeader.jsp
+++ b/src/main/resources/jnt_banner/html/banner.hidden.bannerHeader.jsp
@@ -23,7 +23,8 @@
 <%-- get banner image url. If not provided use default --%>
 <c:choose>
     <c:when test="${not empty bannerImg}">
-        <template:module path='${bannerImg.node.path}' editable='false' view='hidden.contentURL' var="bannerUrl"/>
+        <template:addCacheDependency node="${bannerImg.node}"/>
+        <c:url var="bannerUrl" value="${bannerImg.node.url}" context="/"/>
     </c:when>
     <c:otherwise>
         <c:url value="${url.currentModule}/img/default_banner_img.jpg" var="bannerUrl"/>

--- a/src/main/resources/jnt_imageReference/html/imageReference.jsp
+++ b/src/main/resources/jnt_imageReference/html/imageReference.jsp
@@ -10,8 +10,8 @@
 <c:set var="node" value="${reference.node}"/>
 <%-- display image if referenced image is available --%>
 <c:if test="${not empty node}">
-    <template:addCacheDependency node="${rnode}" />
-    <template:module node='${node}' editable='false' view='hidden.contentURL' var="url"/>
+    <template:addCacheDependency node="${node}" />
+    <c:url var="url" value="${node.url}" context="/"/>
     <img src="${url}" alt="${fn:escapeXml(not empty title.string ? title.string : currentNode.name)}" width="100%"
          height="100%"/> />
 </c:if>

--- a/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
+++ b/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
@@ -16,14 +16,15 @@
 <%-- only display if image is available --%>
 <c:if test="${not empty node}">
     <template:addCacheDependency node="${node}" />
-    <template:module node='${node}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+    <c:url var="imageUrl" value="${node.url}" context="/"/>
 
     <%-- check that the url is valie --%>
     <c:if test="${not empty target.string}"><c:set var="target"> target="${target.string}"</c:set></c:if>
     <c:set var="linknode" value="${linkreference.node}"/>
 
     <c:if test="${not empty linknode}">
-        <template:module node='${linknode}' editable='false' view='hidden.contentURL' var="linkUrl"/>
+        <template:addCacheDependency node="${linknode}"/>
+        <c:url var="linkUrl" value="${linknode.url}" context="/"/>
         <template:module node='${linknode}' editable='false' view='hidden.displayableName' var="linkTitle"/>
     </c:if>
     <c:if test="${empty linkUrl and not empty externalUrl}">

--- a/src/main/resources/jnt_news/html/news.alternating.jsp
+++ b/src/main/resources/jnt_news/html/news.alternating.jsp
@@ -18,7 +18,8 @@
 <c:url var="detailUrl" value="${url.base}${currentNode.path}.html"/>
 
 <c:if test="${not empty newsImage}">
-    <template:module node='${newsImage}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+    <template:addCacheDependency node="${newsImage}"/>
+    <c:url var="imageUrl" value="${newsImage.url}" context="/"/>
     <div class="timeline-heading">
         <img class="img-responsive" src="${imageUrl}" alt=""/>
     </div>

--- a/src/main/resources/jnt_news/html/news.cm.jsp
+++ b/src/main/resources/jnt_news/html/news.cm.jsp
@@ -22,9 +22,10 @@
 <fmt:formatDate dateStyle="long" value="${currentNode.properties['date'].time}" var="newsDate"/>
 <news class="newsFullPreview">
 	<h1>${currentNode.properties['jcr:title'].string}</h1>
-        <c:if test="${not empty newsImage.node}">
-            <img class="newsFullPreview" src="<template:module node='${newsImage.node}' editable='false' view='hidden.contentURL' />" alt="news">
-        </c:if>
+	<c:if test="${not empty newsImage.node}">
+		<template:addCacheDependency node="${newsImage.node}"/>
+		<img class="newsFullPreview" src="<c:url value="${newsImage.node.url}" context="/"/>" alt="news">
+	</c:if>
 	<div>
   		<span>${newsDate}</span>
   		${currentNode.properties['desc'].string}

--- a/src/main/resources/jnt_news/html/news.company.jsp
+++ b/src/main/resources/jnt_news/html/news.company.jsp
@@ -23,7 +23,8 @@
         <c:set var="imageUrl" value="${url.currentModule}/img/default_img.jpg"/>
     </c:when>
     <c:otherwise>
-        <template:module node='${newsImage.node}' editable='false' view='hidden.contentURL' var="imageUrl"/>
+        <template:addCacheDependency node="${newsImage.node}"/>
+        <c:url var="imageUrl" value="${newsImage.node.url}" context="/"/>
     </c:otherwise>
 </c:choose>
 

--- a/src/main/resources/jnt_news/html/news.detail.jsp
+++ b/src/main/resources/jnt_news/html/news.detail.jsp
@@ -41,7 +41,8 @@
 
     <div id="sync1" class="owl-carousel newsPicture">
         <c:if test="${not empty newsImage}">
-            <template:module node='${newsImage}' editable='false' view='hidden.contentURL' var="newsImageUrl"/>
+            <template:addCacheDependency node="${newsImage}"/>
+            <c:url var="newsImageUrl" value="${newsImage.url}" context="/"/>
             <div class="item">
                 <%-- if there is a gallery format for the photoswipe otherwise just display image --%>
             <c:if test="${not empty galleryImgs}"><a href="${newsImageUrl}"

--- a/src/main/resources/jnt_news/html/news.hidden.newsroomfirst.jsp
+++ b/src/main/resources/jnt_news/html/news.hidden.newsroomfirst.jsp
@@ -26,7 +26,8 @@
     <c:when test="${nodePosition == 1 && topLevel == 'first'}">
         <div class="news-v3 margin-bottom-20">
             <c:if test="${not empty newsImage}">
-                <a href="${detailUrl}"><img class="img-responsive full-width" src="<template:module node='${newsImage}' editable='false' view='hidden.contentURL' />" alt="${newsTitle}"></a>
+                <template:addCacheDependency node="${newsImage}"/>
+                <a href="${detailUrl}"><img class="img-responsive full-width" src="<c:url value="${newsImage.url}" context="/"/>" alt="${newsTitle}"></a>
             </c:if>
             <div class="news-v3-in">
                 <template:include view="hidden.tagListView"/>
@@ -46,7 +47,8 @@
         </c:if>
         <div class="col-md-4 sm-margin-bottom-20">
             <div class="news-v2-badge">
-                <a href="${detailUrl}"><img class="img-responsive" src="<template:module node='${newsImage}' editable='false' view='hidden.contentURL' />" alt="${newsTitle}"></a>
+                <template:addCacheDependency node="${newsImage}"/>
+                <a href="${detailUrl}"><img class="img-responsive" src="<c:url value="${newsImage.url}" context="/"/>" alt="${newsTitle}"></a>
                 <p>
                     <span>${newsDay}</span>
                     <small>${newsMonth}</small>

--- a/src/main/resources/jnt_news/html/news.hidden.newsroomsecond.jsp
+++ b/src/main/resources/jnt_news/html/news.hidden.newsroomsecond.jsp
@@ -27,8 +27,8 @@
 <div class="row margin-bottom-20">
     <div class="col-sm-5 sm-margin-bottom-20">
         <c:if test="${not empty newsImage}">
-
-            <a href="${detailUrl}"><img class="img-responsive" src="<template:module node='${newsImage}' editable='false' view='hidden.contentURL' />" alt="${newsTitle}"></a>
+            <template:addCacheDependency node="${newsImage}"/>
+            <a href="${detailUrl}"><img class="img-responsive" src="<c:url value="${newsImage.url}" context="/"/>" alt="${newsTitle}"></a>
         </c:if>
     </div>
     <div class="col-sm-7 news-v3">

--- a/src/main/resources/jnt_news/html/news.jsp
+++ b/src/main/resources/jnt_news/html/news.jsp
@@ -20,8 +20,8 @@
 <div class="row margin-bottom-20">
     <div class="col-sm-5 sm-margin-bottom-20">
         <c:if test="${not empty newsImage.node}">
-
-            <img class="img-responsive" src="<template:module node='${newsImage.node}' editable='false' view='hidden.contentURL' />" alt="">
+            <template:addCacheDependency node="${newsImage.node}"/>
+            <img class="img-responsive" src="<c:url value="${newsImage.node.url}" context="/"/>" alt="">
         </c:if>
     </div>
     <div class="col-sm-7 news-v3">

--- a/src/main/resources/jnt_news/html/news.timeline.jsp
+++ b/src/main/resources/jnt_news/html/news.timeline.jsp
@@ -28,7 +28,8 @@
                 <div class="row">
                     <div class="col-md-4">
 
-                        <img class="img-responsive" src="<template:module node='${newsImage.node}' editable='false' view='hidden.contentURL' />" alt=""/>
+                        <template:addCacheDependency node="${newsImage.node}"/>
+                        <img class="img-responsive" src="<c:url value="${newsImage.node.url}" context="/"/>" alt=""/>
 
                         <div class="md-margin-bottom-20"></div>
                     </div>

--- a/src/main/resources/jnt_person/html/person.condensed.jsp
+++ b/src/main/resources/jnt_person/html/person.condensed.jsp
@@ -33,7 +33,8 @@
         <c:set var="photoUrl" value="${url.currentModule}/img/default_person_img.jpg"/>
     </c:when>
     <c:otherwise>
-        <template:module node='${photo.node}' editable='false' view='hidden.contentURL' var="photoUrl" />
+        <template:addCacheDependency node="${photo.node}"/>
+        <c:url var="photoUrl" value="${photo.node.url}" context="/"/>
     </c:otherwise>
 </c:choose>
 

--- a/src/main/resources/jnt_person/html/person.jsp
+++ b/src/main/resources/jnt_person/html/person.jsp
@@ -46,7 +46,8 @@
                         <img src="${photoUrl}" alt="${name}"/>
                     </c:when>
                     <c:otherwise>
-                        <img src="<template:module node='${photo.node}' editable='false' view='hidden.contentURL' />" alt="${name}"/>
+                        <template:addCacheDependency node="${photo.node}"/>
+                        <img src="<c:url value="${photo.node.url}" context="/"/>" alt="${name}"/>
                     </c:otherwise>
                 </c:choose>
 

--- a/src/main/resources/jnt_press/html/press.fileAttachment.jsp
+++ b/src/main/resources/jnt_press/html/press.fileAttachment.jsp
@@ -22,6 +22,8 @@
 <c:set var="title" value="${currentNode.properties['jcr:title'].string}"/>
 <jcr:nodeProperty node="${currentNode}" name="pdfVersion" var="pdfVersion"/>
 <c:if test="${not empty pdfVersion}">
+    <template:addCacheDependency node="${pdfVersion.node}"/>
+    <c:url var="pdfVersionUrl" value="${pdfVersion.node.url}" context="/"/>
     <c:set var="label" value="${currentNode.properties.downloadTitle.string}"/>
     <c:if test="${empty label}">
         <c:set var="label"><fmt:message key="jdmix_fileAttachment.label"/></c:set>
@@ -35,12 +37,13 @@
                         <i class="fa fa-fw fa-eye" title="<fmt:message key="label.view"/>"></i>
                     </strong>
                     <div class="pdf-preview" style="display: none;">
-                        <object type="application/pdf" data="<template:module node='${currentNode.properties.pdfVersion.node}' editable='false' view='hidden.contentURL' />" width="100%" height="500"><fmt:message key="label.pdfView.noSupport"/><br/><a href="<template:module node='${currentNode.properties.pdfVersion.node}' editable='false' view='hidden.contentURL' />"><strong>${pdfVersion.node.name} <i class="fa fa-download" title="<fmt:message key="label.download"/>"></i></strong></a></object>
+
+                        <object type="application/pdf" data="${pdfVersionUrl}" width="100%" height="500"><fmt:message key="label.pdfView.noSupport"/><br/><a href="${pdfVersionUrl}"><strong>${pdfVersion.node.name} <i class="fa fa-download" title="<fmt:message key="label.download"/>"></i></strong></a></object>
                     </div>
                 </a>
             </c:if>
             &nbsp;
-            <a href="<template:module node='${currentNode.properties.pdfVersion.node}' editable='false' view='hidden.contentURL' />">
+            <a href="${pdfVersionUrl}">
                 <strong>
                     <i class="fa fa-download" title="<fmt:message key="label.download"/>"></i>
                 </strong>

--- a/src/main/resources/jnt_video/html/video.jsp
+++ b/src/main/resources/jnt_video/html/video.jsp
@@ -37,7 +37,8 @@
                preload="${renderContext.editMode ? "metadata" : "auto"}"
                width="${currentNode.properties.width.string}" height="${currentNode.properties.height.string}"
                data-setup='{"techOrder":["html5"]}'>
-          <source src="<template:module node='${currentNode.properties.source.node}' editable='false' view='hidden.contentURL' />" type='${mimeType.string == "video/x-f4v" ? "video/mp4" : mimeType.string}' />
+            <template:addCacheDependency node="${currentNode.properties.source.node}"/>
+          <source src="<c:url value="${currentNode.properties.source.node.url}" context="/"/>" type='${mimeType.string == "video/x-f4v" ? "video/mp4" : mimeType.string}' />
         </video>
     </c:otherwise>
 </c:choose>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/TECH-2055

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Replace the usages of `<template:module>` used as HTML tags attributes, as it prevents the `HtmlTagAttributeVisitor` visitors (in particular the `UrlRewriteVisitor`) to be called for those tags, causing issues with _Cloudimage_ that relies on URL rewrite rules.
Similar to https://github.com/Jahia/jahia-base-demo-components/pull/29.
