### PR TITLE
fix: prevent accidental XSS in the title

### DIFF
--- a/src/main/resources/jnt_event/html/event.cm.jsp
+++ b/src/main/resources/jnt_event/html/event.cm.jsp
@@ -21,16 +21,16 @@
 <fmt:formatDate dateStyle="long" value="${currentNode.properties['startDate'].time}" var="startDate"/>
 <fmt:formatDate dateStyle="long" value="${currentNode.properties['endDate'].time}" var="endDate"/>
 <event class="eventPreview">
-  <h1>  ${currentNode.properties['jcr:title'].string}</h1>
+  <h1>${fn:escapeXml(currentNode.properties['jcr:title'].string)}</h1>
   <div>
     <ul>
         <c:if test="${not empty currentNode.properties['eventsType']}">
-			<li><span>${currentNode.properties['eventsType'].string}</span></li>
+			<li><span>${fn:escapeXml(currentNode.properties['eventsType'].string)}</span></li>
         </c:if>
-      <li><b>${currentNode.properties['location'].string}</b></li>
-	  <li>${startDate} 
+      <li><b>${fn:escapeXml(currentNode.properties['location'].string)}</b></li>
+	  <li>${fn:escapeXml(startDate)} 
 	   <c:if test="${not empty currentNode.properties['endDate']}">
-		- ${endDate}
+		- ${fn:escapeXml(endDate)}
 	   </c:if>
 	  </li>
     </ul>

--- a/src/main/resources/jnt_news/html/news.cm.jsp
+++ b/src/main/resources/jnt_news/html/news.cm.jsp
@@ -21,13 +21,13 @@
 <c:set var="newsImage" value="${currentNode.properties['image']}"/>
 <fmt:formatDate dateStyle="long" value="${currentNode.properties['date'].time}" var="newsDate"/>
 <news class="newsFullPreview">
-	<h1>${currentNode.properties['jcr:title'].string}</h1>
+	<h1>${fn:escapeXml(currentNode.properties['jcr:title'].string)}</h1>
 	<c:if test="${not empty newsImage.node}">
 		<template:addCacheDependency node="${newsImage.node}"/>
 		<img class="newsFullPreview" src="<c:url value="${newsImage.node.url}" context="/"/>" alt="news">
 	</c:if>
 	<div>
-  		<span>${newsDate}</span>
+  		<span>${fn:escapeXml(newsDate)}</span>
   		${currentNode.properties['desc'].string}
 	</div>
 </news>


### PR DESCRIPTION
### Description

Creating an article named _Know everything about <script> tags_ or _Jahia <​3 Open Source_ will inadvertently break the page. This does not protect against malicious users (they can inject JS in the article body), but makes the website more robust in its normal usage scenario.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
